### PR TITLE
New feature: Add arguments to allow generating lighter versions of the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,13 @@ The dashboard has an overview section with a 'Top 10 CloudTrail Events exploited
 
 Then, events are organized according to MITRE ATT&CK tactics. Each event is presented with two widgets: one provides a description, a direct link to traildiscover.cloud, and references to related incidents and research; the other features a counter displaying the frequency of these events in your AWS environment.
 
+**Warning**
+This dashboard is resource-intensive. If you want to generate a dashboard with less data it is possible to use the options `--on-the-wild-only` to only add events that have been seen in the wild, or the `--tactics` option to only add specific tactics. Example usage:For example: `python3 datadog_dashboard.py --on-the-wild-only --tactics "TA0005 - Defense Evasion" "TA0008 - Lateral Movement"`
+
 <p align="center">
   <img src="./docs/traildiscover_datadog_dashboard.gif" alt="Datadog_TrailDiscover_Dashboard" width="600" />
 </p>
+
 ## Plans for the Future
 
 - **Adding More Events**: I'll keep adding new events and updating the info for existing ones.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Then, events are organized according to MITRE ATT&CK tactics. Each event is pres
 
 **Warning**
 
-This dashboard is resource-intensive. If you want to generate a dashboard with less data it is possible to use the options `--on-the-wild-only` to only add events that have been seen in the wild, or the `--tactics` option to only add specific tactics. Example usage
+This dashboard is resource-intensive. If you want to generate a dashboard with fewer data it is possible to use the options `--on-the-wild-only` to only add events that have been seen in the wild, or the `--tactics` option to only add specific tactics. Example usage:
  `python3 datadog_dashboard.py --on-the-wild-only --tactics "TA0005 - Defense Evasion" "TA0008 - Lateral Movement"`
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The dashboard has an overview section with a 'Top 10 CloudTrail Events exploited
 
 Then, events are organized according to MITRE ATT&CK tactics. Each event is presented with two widgets: one provides a description, a direct link to traildiscover.cloud, and references to related incidents and research; the other features a counter displaying the frequency of these events in your AWS environment.
 
-> **Warning**
+> **⚠️ Warning**
+>
 > This dashboard is resource-intensive. If you want to generate a dashboard with fewer data it is possible to use the options `--on-the-wild-only` to only add events that have been seen in the wild, or the `--tactics` option to only add specific tactics. Example usage:
 > `python3 datadog_dashboard.py --on-the-wild-only --tactics "TA0005 - Defense Evasion" "TA0008 - Lateral Movement"`
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ The dashboard has an overview section with a 'Top 10 CloudTrail Events exploited
 Then, events are organized according to MITRE ATT&CK tactics. Each event is presented with two widgets: one provides a description, a direct link to traildiscover.cloud, and references to related incidents and research; the other features a counter displaying the frequency of these events in your AWS environment.
 
 **Warning**
-This dashboard is resource-intensive. If you want to generate a dashboard with less data it is possible to use the options `--on-the-wild-only` to only add events that have been seen in the wild, or the `--tactics` option to only add specific tactics. Example usage:For example: `python3 datadog_dashboard.py --on-the-wild-only --tactics "TA0005 - Defense Evasion" "TA0008 - Lateral Movement"`
+
+This dashboard is resource-intensive. If you want to generate a dashboard with less data it is possible to use the options `--on-the-wild-only` to only add events that have been seen in the wild, or the `--tactics` option to only add specific tactics. Example usage
+ `python3 datadog_dashboard.py --on-the-wild-only --tactics "TA0005 - Defense Evasion" "TA0008 - Lateral Movement"`
+
 
 <p align="center">
   <img src="./docs/traildiscover_datadog_dashboard.gif" alt="Datadog_TrailDiscover_Dashboard" width="600" />

--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ The dashboard has an overview section with a 'Top 10 CloudTrail Events exploited
 
 Then, events are organized according to MITRE ATT&CK tactics. Each event is presented with two widgets: one provides a description, a direct link to traildiscover.cloud, and references to related incidents and research; the other features a counter displaying the frequency of these events in your AWS environment.
 
-**Warning**
-
-This dashboard is resource-intensive. If you want to generate a dashboard with fewer data it is possible to use the options `--on-the-wild-only` to only add events that have been seen in the wild, or the `--tactics` option to only add specific tactics. Example usage:
- `python3 datadog_dashboard.py --on-the-wild-only --tactics "TA0005 - Defense Evasion" "TA0008 - Lateral Movement"`
+> **Warning**
+> This dashboard is resource-intensive. If you want to generate a dashboard with fewer data it is possible to use the options `--on-the-wild-only` to only add events that have been seen in the wild, or the `--tactics` option to only add specific tactics. Example usage:
+> `python3 datadog_dashboard.py --on-the-wild-only --tactics "TA0005 - Defense Evasion" "TA0008 - Lateral Movement"`
 
 
 <p align="center">


### PR DESCRIPTION
The Datadog dashboard is resource-intensive. For this reason, I've added arguments to allow generating a dashboard with fewer data. It is now possible to use the options `--on-the-wild-only` to only add events that have been seen in the wild, or the `--tactics` option to only add specific tactics. Example usage:
 `python3 datadog_dashboard.py --on-the-wild-only --tactics "TA0005 - Defense Evasion" "TA0008 - Lateral Movement"`